### PR TITLE
Add dist to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bower_components/
 .idea/
 .sass-cache/
 .DS_Store
+dist

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -74,7 +74,6 @@ module.exports = function(grunt) {
     });
 
     grunt.loadNpmTasks('grunt-contrib-watch');
-    grunt.loadNpmTasks('grunt-contrib-copy');
     grunt.loadNpmTasks('grunt-contrib-clean');
     grunt.loadNpmTasks('grunt-hapi');
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -74,6 +74,7 @@ module.exports = function(grunt) {
     });
 
     grunt.loadNpmTasks('grunt-contrib-watch');
+    grunt.loadNpmTasks('grunt-contrib-copy');
     grunt.loadNpmTasks('grunt-contrib-clean');
     grunt.loadNpmTasks('grunt-hapi');
 


### PR DESCRIPTION
I am not too crazy about this Gruntfile, seems redundant to always build, but I guess I am used to a gulp and webpack at this, but regardless --  the student doesn't not need the dist folder saved in git while working on the app. It causes confusion
