### PR TITLE
Add dist folder to the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bower_components/
 .idea/
 .sass-cache/
 .DS_Store
+dist/


### PR DESCRIPTION
Students seem to invariably have trouble with the `dist` folder getting committed when they first start with this starter project. Ignoring it for them could make their lives (and their mentors') much easier.