### PR TITLE
Updates Grunt file to only build dist when requested

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bower_components/
 .idea/
 .sass-cache/
 .DS_Store
+dist

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -18,10 +18,6 @@ module.exports = function(grunt) {
                     './app/templates/**/*.html',
                     'Gruntfile.js'
                 ],
-                tasks: [
-                    'clean',
-                    'copy'
-                ],
                 options: {
                     spawn: false
                 }
@@ -64,7 +60,7 @@ module.exports = function(grunt) {
                 options: {
                     server: require('path').resolve('./server'),
                     bases: {
-                        '/dist': require('path').resolve('./dist/')
+                        '/app': require('path').resolve('./app/pages')
                     }
                 }
             }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -74,7 +74,6 @@ module.exports = function(grunt) {
     });
 
     grunt.loadNpmTasks('grunt-contrib-watch');
-    grunt.loadNpmTasks('grunt-contrib-copy');
     grunt.loadNpmTasks('grunt-contrib-clean');
     grunt.loadNpmTasks('grunt-hapi');
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -74,6 +74,7 @@ module.exports = function(grunt) {
     });
 
     grunt.loadNpmTasks('grunt-contrib-watch');
+    grunt.loadNpmTasks('grunt-contrib-copy');
     grunt.loadNpmTasks('grunt-contrib-clean');
     grunt.loadNpmTasks('grunt-hapi');
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "grunt run",
+    "build": "grunt build"
   },
   "author": "Bloc Inc",
   "license": "ISC",


### PR DESCRIPTION
# What is this?

SO..... I am not a fan of Grunt and feel like it is out date when it comes to frontend web development. I also get annoyed that we are copying to the dist folder everytime we run Grunt, similar to the reasoning for #22.

This is confusing for students to grasp since we are not recommending deployment (until recently). Also, we are not doing any bundling or minification, which makes `copy` a silly task to run all the time. 

I am going to open a phab task to add webpack to this, that includes actual bundling and minification.

I also added the grunt tasks to npm, since that is also an industry standard for a frontend task runner. 

# What did I do?

I change the location for the grunt server to point to the active `app/pages/index.html` and removed dist tasks from the watch command. 

IMO: Ideally if someone is ready to deploy you will run the deploy command and build yours assets, in development there is no reason to constantly update that.

This falls in line with how some of the modern deployment tools work, [Firebase hosting](https://firebase.google.com/docs/hosting/), [Surge](https://surge.sh/), and  [Netlify](https://www.netlify.com/) 
